### PR TITLE
fix(cors): ensure CORS filter registers allowed origins

### DIFF
--- a/src/main/java/com/iotiq/user/security/config/WebConfig.java
+++ b/src/main/java/com/iotiq/user/security/config/WebConfig.java
@@ -10,7 +10,6 @@ import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerF
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -83,13 +82,17 @@ public class WebConfig implements ServletContextInitializer, WebServerFactoryCus
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
-        if (!CollectionUtils.isEmpty(config.getAllowedOrigins()) || !CollectionUtils.isEmpty(config.getAllowedOriginPatterns())) {
-            log.debug("Registering CORS filter");
-            source.registerCorsConfiguration("/api/**", config);
-            source.registerCorsConfiguration("/management/**", config);
-            source.registerCorsConfiguration("/v3/api-docs", config);
-            source.registerCorsConfiguration("/swagger-ui/**", config);
-        }
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setAllowCredentials(true);
+
+        // Register CORS configuration for specific paths
+        source.registerCorsConfiguration("/api/**", config);
+        source.registerCorsConfiguration("/management/**", config);
+        source.registerCorsConfiguration("/v3/api-docs", config);
+        source.registerCorsConfiguration("/swagger-ui/**", config);
+        log.debug("Registering CORS filter with allowed settings");
         return new CorsFilter(source);
     }
 }


### PR DESCRIPTION
- Added allowed origins and patterns to the CORS configuration.
- Removed conditional check that prevented CORS from being registered when no origins were set.
- Ensured that CORS configuration is applied to `/api/**`, `/management/**`, `/v3/api-docs`, and `/swagger-ui/**`.

This resolves an issue where CORS was not applied due to an empty allowed origins check.