### PR TITLE
fix: update CORS configuration to use WebMvcConfigurer

### DIFF
--- a/src/main/java/com/iotiq/user/security/config/WebConfig.java
+++ b/src/main/java/com/iotiq/user/security/config/WebConfig.java
@@ -10,9 +10,8 @@ import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerF
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -79,20 +78,14 @@ public class WebConfig implements ServletContextInitializer, WebServerFactoryCus
     }
 
     @Bean
-    public CorsFilter corsFilter() {
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOriginPattern("*");
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
-        config.setAllowCredentials(true);
-
-        // Register CORS configuration for specific paths
-        source.registerCorsConfiguration("/api/**", config);
-        source.registerCorsConfiguration("/management/**", config);
-        source.registerCorsConfiguration("/v3/api-docs", config);
-        source.registerCorsConfiguration("/swagger-ui/**", config);
-        log.debug("Registering CORS filter with allowed settings");
-        return new CorsFilter(source);
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE");
+            }
+        };
     }
 }


### PR DESCRIPTION
Replaced CorsFilter bean configuration with WebMvcConfigurer for CORS settings. Updated allowed origins and methods for API paths.